### PR TITLE
Update the quickTestSourceDirectory property

### DIFF
--- a/share/imports/Stoiridh/QtQuick/QmlAutotest.qbs
+++ b/share/imports/Stoiridh/QtQuick/QmlAutotest.qbs
@@ -29,7 +29,7 @@ QtQuick.Autotest {
     ////////////////////////////////////////////////////////////////////////////////////////////////
     //  Properties                                                                                //
     ////////////////////////////////////////////////////////////////////////////////////////////////
-    property path quickTestSourceDirectory: FileInfo.joinPaths(product.sourceDirectory, 'qml')
+    property path quickTestSourceDirectory: FileInfo.joinPaths(product.sourceDirectory, 'data')
     readonly property bool isAbsolutePath: FileInfo.isAbsolutePath(quickTestSourceDirectory)
 
     ////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This minor update replaces 'qml' by 'data' as default directory name.

Task-number: #4