### PR TITLE
Improve verbosity

### DIFF
--- a/doc/source/library/config.rst
+++ b/doc/source/library/config.rst
@@ -1,9 +1,10 @@
-:py:mod:`stoiridhtools.config` --- Handle the settings of |project|
+:py:mod:`stoiridhtools.config` --- Handle the settings
 ====================================================================================================
 
 .. Copyright 2015-2016 Stòiridh Project.
 .. This file is under the FDL licence, see LICENCE.FDL for details.
 
+.. moduleauthor:: William McKIE <mckie.william@hotmail.co.uk>
 .. sectionauthor:: William McKIE <mckie.william@hotmail.co.uk>
 
 .. py:module:: stoiridhtools.config

--- a/doc/source/library/index.rst
+++ b/doc/source/library/index.rst
@@ -1,4 +1,4 @@
-|project| --- Python 3 API Reference
+Core Services
 ====================================================================================================
 
 .. Copyright 2015-2016 Stòiridh Project.
@@ -8,10 +8,13 @@
 
 ----------------------------------------------------------------------------------------------------
 
-Welcome to the |project| Python 3 API Reference!
+The modules described in this chapter provide tools for downloading new packages or access to the
+|project| configuration.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
-   library/index
-   library/qbs/index
+   stoiridhtools
+   config
+   sdk
+   versionnumber

--- a/doc/source/library/qbs/index.rst
+++ b/doc/source/library/qbs/index.rst
@@ -1,21 +1,17 @@
-:py:mod:`stoiridhtools.qbs` module
+Qbs Services
 ====================================================================================================
 
 .. Copyright 2015-2016 Stòiridh Project.
 .. This file is under the FDL licence, see LICENCE.FDL for details.
 
-.. moduleauthor:: William McKIE <mckie.william@hotmail.co.uk>
 .. sectionauthor:: William McKIE <mckie.william@hotmail.co.uk>
-
-.. py:module:: stoiridhtools.qbs
 
 ----------------------------------------------------------------------------------------------------
 
-The :py:mod:`stoiridhtools.qbs` module provides a tool to scan the environment variables of the
-Operating System in order to find :term:`Qbs`.
+The modules described in this chapter provide tools to interact with :term:`Qbs`.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
-   qbs/qbs
-   qbs/scanner
+   qbs
+   scanner

--- a/doc/source/library/qbs/qbs.rst
+++ b/doc/source/library/qbs/qbs.rst
@@ -1,4 +1,4 @@
-:py:mod:`stoiridhtools.qbs` --- Wrapper for a Qbs executble
+:py:mod:`stoiridhtools.qbs` --- Wrapper for a Qbs executable
 ====================================================================================================
 
 .. Copyright 2015-2016 Stòiridh Project.
@@ -6,9 +6,16 @@
 
 .. sectionauthor:: William McKIE <mckie.william@hotmail.co.uk>
 
-.. py:currentmodule:: stoiridhtools.qbs
+.. py:module:: stoiridhtools.qbs
+   :synopsis: Wrapper for a Qbs executable
 
 ----------------------------------------------------------------------------------------------------
+
+Introduction
+------------
+
+The :py:mod:`stoiridhtools.qbs` module provides a tool to scan the environment variables of the
+Operating System in order to find :term:`Qbs`.
 
 Objects
 -------

--- a/doc/source/library/qbs/scanner.rst
+++ b/doc/source/library/qbs/scanner.rst
@@ -4,6 +4,7 @@
 .. Copyright 2015-2016 Stòiridh Project.
 .. This file is under the FDL licence, see LICENCE.FDL for details.
 
+.. moduleauthor:: William McKIE <mckie.william@hotmail.co.uk>
 .. sectionauthor:: William McKIE <mckie.william@hotmail.co.uk>
 
 .. py:module:: stoiridhtools.qbs.scanner

--- a/doc/source/library/sdk.rst
+++ b/doc/source/library/sdk.rst
@@ -4,6 +4,7 @@
 .. Copyright 2015-2016 Stòiridh Project.
 .. This file is under the FDL licence, see LICENCE.FDL for details.
 
+.. moduleauthor:: William McKIE <mckie.william@hotmail.co.uk>
 .. sectionauthor:: William McKIE <mckie.william@hotmail.co.uk>
 
 .. py:module:: stoiridhtools.sdk

--- a/doc/source/library/stoiridhtools.rst
+++ b/doc/source/library/stoiridhtools.rst
@@ -1,4 +1,4 @@
-:py:mod:`stoiridhtools` module
+:py:mod:`stoiridhtools` --- Control verbosity between submodules
 ====================================================================================================
 
 .. Copyright 2015-2016 Stòiridh Project.
@@ -8,14 +8,33 @@
 .. sectionauthor:: William McKIE <mckie.william@hotmail.co.uk>
 
 .. py:module:: stoiridhtools
+   :synopsis: Control verbosity between submodules
 
 ----------------------------------------------------------------------------------------------------
 
-The :py:mod:`stoiridhtools` module provides an interface to handle the versions of |project|.
+Introduction
+------------
 
-.. toctree::
-   :maxdepth: 2
+The :py:mod:`stoiridhtools` module provides some utility functions in order to control the verbosity
+between submodules.
 
-   config
-   sdk
-   versionnumber
+Functions
+---------
+
+.. py:function:: enable_verbosity(enable)
+
+   Enable or disable the verbosity of the messages.
+
+.. py:function:: vprint(message)
+
+   Print a verbose message in the :py:data:`sys.stdout`, if and only if the
+   :py:func:`enable_verbosity` is enabled.
+
+.. py:function:: vsprint(message)
+
+   Print a verbose step message in the :py:data:`sys.stdout`, if and only if the
+   :py:func:`enable_verbosity` is enabled.
+
+   .. note::
+
+      A step message starts with a ``::`` character.

--- a/doc/source/library/versionnumber.rst
+++ b/doc/source/library/versionnumber.rst
@@ -4,6 +4,7 @@
 .. Copyright 2015-2016 Stòiridh Project.
 .. This file is under the FDL licence, see LICENCE.FDL for details.
 
+.. moduleauthor:: William McKIE <mckie.william@hotmail.co.uk>
 .. sectionauthor:: William McKIE <mckie.william@hotmail.co.uk>
 
 .. py:module:: stoiridhtools.versionnumber

--- a/stoiridhtools/__init__.py
+++ b/stoiridhtools/__init__.py
@@ -18,3 +18,38 @@
 ##                                                                                                ##
 ####################################################################################################
 __version__ = '0.1.0'
+__all__ = ['__version__', 'enable_verbosity', 'vprint', 'vsprint']
+
+
+# constants
+PROJECT_NAME = 'Stòiridh Tools'
+SUPPORTED_VERSIONS = ['0.1.0']
+
+
+# private class
+class Verbosity:
+    enable = False
+
+
+def enable_verbosity(enable):
+    """Enable or disable the verbosity of the messages."""
+    Verbosity.enable = enable
+
+
+def vprint(message):
+    """Print a verbose message in the :py:data:`sys.stdout`, if and only if the
+    :py:func:`enable_verbosity` is enabled."""
+    if Verbosity.enable:
+        print(message)
+
+
+def vsprint(message):
+    """Print a verbose step message in the :py:data:`sys.stdout`, if and only if the
+    :py:func:`enable_verbosity` is enabled.
+
+    .. note::
+
+        A step message starts with a '::' character.
+    """
+    if Verbosity.enable:
+        print('::', message)

--- a/stoiridhtools/cli/__init__.py
+++ b/stoiridhtools/cli/__init__.py
@@ -20,37 +20,24 @@
 import argparse
 import asyncio
 import logging
-import stoiridhtools
 
-# constants
-STOIRIDHTOOLS_PROJECT_NAME = 'Stòiridh Tools'
-STOIRIDHTOOLS_PROJECT_VERSION = stoiridhtools.__version__
-STOIRIDHTOOLS_SUPPORTED_VERSIONS = ['0.1.0']
+from stoiridhtools import enable_verbosity, PROJECT_NAME, __version__
+
 
 LOG = logging.getLogger(__name__)
 
 
 class Command:
     """Argument command"""
-    def __init__(self, parser, name=None, verbose=False, loop=None):
+    def __init__(self, parser, name=None, loop=None):
         self._name = name
         self._parser = parser
-        self._verbose = verbose
         self._loop = loop
 
     @property
     def name(self):
         """Return the name of the command."""
         return self._name
-
-    @property
-    def verbose(self):
-        """Hold the verbosity of the command."""
-        return self._verbose
-
-    @verbose.setter
-    def verbose(self, value):
-        self._verbose = value
 
     def prepare(self):
         """Prepare the arguments that can be used with the command."""
@@ -63,12 +50,6 @@ class Command:
     def _add_verbose_argument(self, parser):
         """Add a *verbose* argument to the given *parser* of the command."""
         parser.add_argument('-v', '--verbose', action='store_true', help="be more verbose")
-
-    def _print_verbose(self, message):
-        """Print a verbose message in the :py:data:`sys.stdout`, if and only if the
-        :py:attr:`verbose` property is :py:data:`True`."""
-        if self.verbose:
-            print(message)
 
 
 class CommandManager:
@@ -85,10 +66,10 @@ class CommandManager:
         self._commands = dict()
         self._loop = None
         self._parser = argparse.ArgumentParser(prog='stoiridhtools',
-                                               description="Setup the %s build environment"
-                                                           % STOIRIDHTOOLS_PROJECT_NAME)
+                                               description='Setup the %s build environment'
+                                                           % PROJECT_NAME)
         self._parser.add_argument('-V', '--version', action='store_true',
-                                  help="show the version number and exit")
+                                  help='show the version number and exit')
         self._command_parser = self._parser.add_subparsers(dest='command', description=None)
 
     def append(self, cmdtype):
@@ -116,12 +97,14 @@ class CommandManager:
         LOG.debug("Parsing the command-line arguments.")
         args = self._parser.parse_args()
 
+        if hasattr(args, 'verbose'):
+            enable_verbosity(args.verbose)
+
         if args.version:
-            print(STOIRIDHTOOLS_PROJECT_VERSION)
+            print(__version__)
         elif args.command in self._commands.keys():
             LOG.debug("Running the command: %s", args.command)
             cmd = self._commands.get(args.command)
-            cmd.verbose = args.verbose if hasattr(args, 'verbose') else False
             cmd.run(args)
         else:
             self._parser.print_help()


### PR DESCRIPTION
Instead of to restrict the verbosity of the messages to the stoiridhtools.cli.Command class, move the verbosity handling directly into the stoiridhtools module in order that all classes from the modules can be able to print verbose messages.

Note also that the constants written in the stoiridhtools.cli submodule has been moved and improved into the stoiridhtools module.
